### PR TITLE
Tom/fix boris

### DIFF
--- a/python/boris_solver.py
+++ b/python/boris_solver.py
@@ -8,14 +8,14 @@ from scipy.constants import electron_mass as me, elementary_charge as qe, c
 from utils import calculate_omega
 
 class BorisSolver():
-    """ 
+    """
     Copy of the QTNM base in the absence of a link to the base class
-    
-    Args:                                                                                            
+
+    Args:
         charge: Charge of the particle
-        mass: Mass of particle                                                                     
-        tau: Larmor power parameter, such that P = tau * mass * a**2                             
-        calc_b_field: Method to calculate magnetic field as function                              
+        mass: Mass of particle
+        tau: Larmor power parameter, such that P = tau * mass * a**2
+        calc_b_field: Method to calculate magnetic field as function
                       of (x, y, z)
     """
     
@@ -27,7 +27,7 @@ class BorisSolver():
         self.tau = tau
 
         if calc_b_field is not None:
-            # Handle cases where calc_b_field returns a single component                             
+            # Handle cases where calc_b_field returns a single component
             if np.size(calc_b_field(0, 0, 0)) == 1:
                 self.calc_b_field = lambda x, y, z: \
                     np.array([0.0, 0.0, calc_b_field(x, y, z)])
@@ -59,10 +59,10 @@ class BorisSolver():
 
     def radiation_acceleration(self, pos, vel):
         """
-        Calculate the acceleration from the radiation reaction force 
+        Calculate the acceleration from the radiation reaction force
         Form is from Ford & O'Connell equation in 3D
 
-        Args: 
+        Args:
             pos: 3D position array
             vel: 3D velocity array
 
@@ -83,11 +83,11 @@ class BorisSolver():
 
         acc[2] -= self.tau * (omega[0]**2 + omega[1]**2) * vel[2]
         acc[2] += self.tau * omega[2] * (omega[0] * vel[0] + omega[1] * vel[1])
-        
+
         acc /= denom
-        
+
         return acc
-    
+
     def advance_step(self, time_step, x0, v0):
         """
         Advances the equations of motions by a single time step using Boris method
@@ -103,7 +103,7 @@ class BorisSolver():
         gamma_n = 1 / np.sqrt( 1.0 - np.dot(v0, v0) / c**2 )    
         u_n = v0 * gamma_n
         x_n = x0
-        v_n = v0        
+        v_n = v0
 
         # Half position step
         x_nplushalf = x_n + v_n * time_step / 2.0
@@ -118,9 +118,9 @@ class BorisSolver():
             B_nplushalf = self.b_field
         else:
             B_nplushalf = self.calc_b_field(x_nplushalf[0], x_nplushalf[1], x_nplushalf[2])
-            
+
         theta = self.charge * time_step / (self.mass * gamma_minus) * np.linalg.norm(B_nplushalf)
-        t = np.tan(theta/2.0) * B_nplushalf / np.linalg.norm(B_nplushalf) 
+        t = np.tan(theta/2.0) * B_nplushalf / np.linalg.norm(B_nplushalf)
         u_prime = u_minus + np.cross(u_minus, t)
         u_plus = u_minus + 2.0 / (1.0 + np.dot(t, t)) * np.cross(u_prime, t)
 
@@ -140,15 +140,15 @@ class BorisSolver():
         """
         Numerically solve equations using Boris method for n_rotations
 
-        Args:                                                                                       
-            n_rotations: Number of gyro-orbits (as function of B(x0))                                  
-            x0: Initial position. Default: (1.0, 0.0, 0.0)                                          
-            v0: Initial velocity. Default: (0.0, 1.0, 0.0)                                            
+        Args:
+            n_rotations: Number of gyro-orbits (as function of B(x0))
+            x0: Initial position. Default: (1.0, 0.0, 0.0)
+            v0: Initial velocity. Default: (0.0, 1.0, 0.0)
 
         Returns times, positions and velocities
         """
 
-        # Calculate magnitude of omega                                                              
+        # Calculate magnitude of omega
         omega0 = np.linalg.norm(self.get_omega(x0))
 
         # Correct for relativity
@@ -158,7 +158,7 @@ class BorisSolver():
         # Maximum time step
         max_step = cfl / omega0
 
-        # Final time                                                                                
+        # Final time
         t_end = n_rotations * 2.0 * np.pi / omega0
 
         # Calculate number of steps
@@ -168,7 +168,7 @@ class BorisSolver():
         u_n = v0 * 1.0 / np.sqrt( 1.0 - np.dot(v0, v0) / c**2 )
         x_n = x0
         v_n = v0
-        
+
         times = np.zeros(n_steps)
         pos   = np.zeros((3, n_steps))
         vel   = np.zeros((3, n_steps))
@@ -211,6 +211,5 @@ class BorisSolver():
 
         # Larmor terms
         acc += self.radiation_acceleration(x, v)
-        
+
         return acc
-    

--- a/python/boris_solver.py
+++ b/python/boris_solver.py
@@ -156,13 +156,13 @@ class BorisSolver():
         omega0 /= gamma
 
         # Maximum time step
-        max_step = cfl / omega0
+        max_step = 2.0 * np.pi * cfl / omega0
 
         # Final time
         t_end = n_rotations * 2.0 * np.pi / omega0
 
         # Calculate number of steps
-        n_steps = int(np.ceil(t_end / max_step))
+        n_steps = int(np.ceil(t_end / max_step)) + 1
         step_size = max_step
 
         u_n = v0 * 1.0 / np.sqrt( 1.0 - np.dot(v0, v0) / c**2 )

--- a/python/boris_solver.py
+++ b/python/boris_solver.py
@@ -151,7 +151,11 @@ class BorisSolver():
         # Calculate magnitude of omega                                                              
         omega0 = np.linalg.norm(self.get_omega(x0))
 
-        # Maximum time step                                                                          
+        # Correct for relativity
+        gamma = 1 / np.sqrt( 1.0 - np.dot(v0, v0) / c**2 )
+        omega0 /= gamma
+
+        # Maximum time step
         max_step = cfl / omega0
 
         # Final time                                                                                

--- a/python/boris_solver.py
+++ b/python/boris_solver.py
@@ -39,6 +39,8 @@ class BorisSolver():
                 self.omega0 = omega0
             elif np.size(omega0) == 1:
                 self.omega0 = np.array([0, 0, omega0], dtype=float)
+                # Boris solver requires a vector for b. Assume B = B_z
+                self.b_field = np.array([0.0, 0.0, b_field])
             else:
                 raise ValueError('Calculate omega returned erroneous size')
 

--- a/python/boris_solver.py
+++ b/python/boris_solver.py
@@ -189,6 +189,8 @@ class BorisSolver():
             vel[1][step] = vel_n[1]
             vel[2][step] = vel_n[2]
 
+        return times, pos, vel
+
     def acc(self, x, v):
         """
         Returns acceleration due B field and radiation losses

--- a/python/qtnm_base.py
+++ b/python/qtnm_base.py
@@ -98,7 +98,7 @@ class QtnmBaseSolver(ABC):
         omega0 = np.linalg.norm(self.get_omega(x0))
 
         # Maximum time step
-        max_step = cfl / omega0
+        max_step = 2.0 * np.pi * cfl / omega0
 
         # Final time
         t_end = n_rotations * 2.0 * np.pi / omega0


### PR DESCRIPTION
Minor fixes for python Boris solver:

1. Fix default case of scalar magnetic field. Now stored as a vector (to allow cross product).
2. Return solution from `solve` method.