### PR TITLE
Tom/scattering density

### DIFF
--- a/examples/ScatteringExample/src/SEDetectorConstruction.cc
+++ b/examples/ScatteringExample/src/SEDetectorConstruction.cc
@@ -139,7 +139,7 @@ auto SEDetectorConstruction::SetupShort() -> G4VPhysicalVolume*
   G4int nbunches     = (int) (pipehZ / (2*bunchhZ + gap)); // integer, lower limit half number
 
   G4cout << ">> shortPipe: nbunches fit in pipe: " << 2*nbunches-2 << G4endl;
-  G4cout << ">> shortPipe: at density [g/cm3] " << fdensity / (g / cm3) << G4endl;
+  G4cout << ">> shortPipe: at density [g/cm3] " << bunchMat->GetDensity() / (g / cm3) << G4endl;
   
   // stopwatch volume with piperad and thickness in z
   G4double heightZ   = 0.1 * cm;   // 2 mm thick in z

--- a/examples/ScatteringExample/src/SEDetectorConstruction.cc
+++ b/examples/ScatteringExample/src/SEDetectorConstruction.cc
@@ -31,7 +31,6 @@ SEDetectorConstruction::SEDetectorConstruction()
   fdensity = 5.e-12 * g / cm3;
 
   DefineCommands();
-  DefineMaterials();
 }
 
 SEDetectorConstruction::~SEDetectorConstruction()
@@ -46,6 +45,8 @@ auto SEDetectorConstruction::Construct() -> G4VPhysicalVolume*
   G4PhysicalVolumeStore::GetInstance()->Clean();
   G4LogicalVolumeStore::GetInstance()->Clean();
   G4SolidStore::GetInstance()->Clean();
+
+  DefineMaterials();
 
   if(fGeometryName == "bunches")
   {


### PR DESCRIPTION
Fix setting of density in scattering example.

@yramachers As discussed, I think all that was required here was to move the call from the constructor to the `Construct` method, however I've also modified one of the print statement slightly, to make sure the true density being used is printed.